### PR TITLE
Mutate t-rex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,11 @@ _NCrunch_*/
 Artifacts
 *.psess
 *.xml
+!/build/*.xml
 *.nupkg
 /.stignore
 /.stfolder
+.dotnet
+.vscode
 
 \.vs/

--- a/TRexLib.Tests/ParserTests.cs
+++ b/TRexLib.Tests/ParserTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
+using System.Runtime.InteropServices;
 
 namespace TRexLib.Tests
 {
@@ -101,6 +102,11 @@ namespace TRexLib.Tests
         [Fact]
         public void The_path_to_a_Windows_test_project_is_parsed()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
             var results =
                 new FileInfo(Path.Combine("TRXs", "example1_Windows.trx"))
                     .Parse();
@@ -115,6 +121,11 @@ namespace TRexLib.Tests
         [Fact]
         public void The_path_to_a_Windows_test_dll_is_parsed()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
             var results =
                 new FileInfo(Path.Combine("TRXs", "example1_Windows.trx"))
                     .Parse();

--- a/TRexLib.Tests/ParserTests.cs
+++ b/TRexLib.Tests/ParserTests.cs
@@ -4,7 +4,6 @@ using FluentAssertions;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
-using System.Runtime.InteropServices;
 
 namespace TRexLib.Tests
 {
@@ -102,11 +101,6 @@ namespace TRexLib.Tests
         [Fact]
         public void The_path_to_a_Windows_test_project_is_parsed()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return;
-            }
-
             var results =
                 new FileInfo(Path.Combine("TRXs", "example1_Windows.trx"))
                     .Parse();
@@ -121,11 +115,6 @@ namespace TRexLib.Tests
         [Fact]
         public void The_path_to_a_Windows_test_dll_is_parsed()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return;
-            }
-
             var results =
                 new FileInfo(Path.Combine("TRXs", "example1_Windows.trx"))
                     .Parse();

--- a/TRexLib.Tests/TRexLib.Tests.csproj
+++ b/TRexLib.Tests/TRexLib.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,13 @@
 artifacts:
-  - path: '**\*.nupkg'
+  - path: '**\t-rex*.nupkg'
 
 configuration:
   - Release
 
 build_script:
-  - cmd: >-
-      dotnet build TRex.sln /p:VersionPrefix=%APPVEYOR_BUILD_VERSION%
+  - ps: >-
+      ./build.ps1
 
 test_script:
-  - cmd: dotnet test .\TRexLib.Tests\TRexLib.Tests.csproj
+  - ps: >-
+      ./build.ps1 -test

--- a/build.bat
+++ b/build.bat
@@ -1,2 +1,0 @@
-dotnet build TRex.sln -r win10-x64
-dotnet publish t-rex/t-rex.csproj -r win10-x64 -f netcoreapp2.0

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,32 @@
+Param(
+    [switch] $test
+)
+
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
+$env:DOTNET_MULTILEVEL_LOOKUP = 0
+$DotNetCliVersion = "2.1.300-preview1-008174"
+$DotNetRoot = ".dotnet"
+$DotNetInstallScript = Join-Path $DotNetRoot "dotnet-install.ps1"
+
+function Create-Directory([string[]] $Path) {
+    if (!(Test-Path -Path $Path)) {
+        New-Item -Path $Path -Force -ItemType "Directory" | Out-Null
+    }
+}
+
+Create-Directory $DotNetRoot
+Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -UseBasicParsing -OutFile $DotNetInstallScript
+Invoke-Expression -Command "$DotNetInstallScript -Version $DotNetCliVersion -InstallDir $DotNetRoot"
+
+$env:PATH = "$DotNetRoot;$env:PATH"
+
+dotnet build TRex.sln -r win10-x64
+if ($test) {
+    dotnet test TRexLib.Tests/TRexLib.Tests.csproj
+}
+
+$VersionSuffix = "devbuild"
+if ($env:APPVEYOR_BUILD_VERSION -ne $Null -and $env:APPVEYOR_BUILD_VERSION -ne '') {
+    $VersionSuffix=$env:APPVEYOR_BUILD_VERSION
+}
+dotnet pack t-rex/t-rex.csproj /p:AppendVersionSuffix=$VersionSuffix /p:packTool=true

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,40 @@
-dotnet build TRex.sln -r osx.10.11-x64
-dotnet publish t-rex/t-rex.csproj -r osx.10.11-x64 -f netcoreapp2.0
+test=false
+while [[ $# > 0 ]]; do
+	lowerI="$(echo $1 | awk '{print tolower($0)}')"
+	case $lowerI in
+		--test)
+			test=true
+			shift 1
+			;;
+	esac
+done
+
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_MULTILEVEL_LOOKUP=0
+DotNetCliVersion="2.1.300-preview1-008174"
+DotNetRoot=".dotnet"
+DotNetInstallScript="$DotNetRoot/dotnet-install.sh"
+
+function CreateDirectory() {
+	if [ ! -d "$1" ]; then
+		mkdir -p "$1"
+	fi
+}
+
+CreateDirectory "$DotNetRoot"
+curl "https://dot.net/v1/dotnet-install.sh" -sSL -o "$DotNetInstallScript"
+bash "$DotNetInstallScript" --version $DotNetCliVersion --install-dir $DotNetRoot
+
+export PATH="$DotNetRoot:$PATH"
+
+dotnet build TRex.sln -r win10-x64
+if [ $test == "true" ]; then
+	dotnet test TRexLib.Tests/TRexLib.Tests.csproj
+fi
+
+VersionSuffix="devbuild"
+if [ ! -z "$APPVEYOR_BUILD_VERSION" ]; then
+	VersionSuffix="$APPVEYOR_BUILD_VERSION"
+fi
+
+dotnet pack t-rex/t-rex.csproj /p:AppendVersionSuffix=$VersionSuffix /p:packTool=true

--- a/build/DotnetToolSettings.xml
+++ b/build/DotnetToolSettings.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<DotNetCliTool>
+  <Commands>
+    <Command Name="t-rex" EntryPoint="t-rex.dll" Runner="dotnet" />
+  </Commands>
+</DotNetCliTool>

--- a/build/toolpack.target
+++ b/build/toolpack.target
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificBuildOutput);AddPackageFiles</TargetsForTfmSpecificContentInPackage>
+    <PackageType>DotnetTool</PackageType>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Update="@(PackageReference)">
+      <PrivateAssets>All</PrivateAssets>
+      <Publish Condition=" '%(PackageReference.Publish)' != 'false' ">true</Publish>
+    </PackageReference>
+
+    <ProjectReference Update="@(ProjectReference)">
+      <PrivateAssets>All</PrivateAssets>
+      <Publish Condition=" '%(ProjectReference.Publish)' != 'false' ">true</Publish>
+    </ProjectReference>
+
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="2.1.0-preview1-26216-02" />
+  </ItemGroup>
+
+  <Target Name="AddPackageFiles" DependsOnTargets="Publish">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(PublishDir)/**/*.*">
+        <PackagePath>tools/$(targetframework)/any</PackagePath>
+      </TfmSpecificPackageFile>
+    </ItemGroup>
+  </Target>
+
+  <ItemGroup>
+    <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)/DotnetToolSettings.xml">
+      <PackagePath>tools/$(targetframework)/any</PackagePath>
+    </TfmSpecificPackageFile>
+  </ItemGroup>
+</Project>

--- a/t-rex/runtimeconfig.template.json
+++ b/t-rex/runtimeconfig.template.json
@@ -1,0 +1,9 @@
+{
+  "runtimeOptions": {
+    "tfm": "netcoreapp2.1",
+    "framework": {
+      "name": "Microsoft.NETCore.App",
+      "version": "2.1.0-preview"
+    }
+  }
+}

--- a/t-rex/t-rex.csproj
+++ b/t-rex/t-rex.csproj
@@ -1,10 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <OutputType>exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <RootNamespace>TRex.CommandLine</RootNamespace>
+    <Version>1.0.0-preview1-$(AppendVersionSuffix)</Version>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\TRexLib\TRexLib.csproj" />
   </ItemGroup>
+  <Import Condition="'$(PackTool)' == 'true' " Project="..\build\toolpack.target" />
 </Project>


### PR DESCRIPTION
To convert to dotnet tool. I need to carry a preview dotnet in build script. And now to run dev cycle, you need to run build script and then devenv solution.

Preview 1 dotnet pack tool has a lot of limitations. So I used "manual" target. I will replace it with the latest date pack tool when a build came out.

The version looks like this t-rex.1.0.0-preview1-1.0.5.nupkg.

I made a hack on runtime.config. It should be able to run on all preview version of SDK 2.1.3XX

To install, put it in a nuget feed first and then `dotnet install tool -g t-rex --version t-rex.1.0.0-preview1-1.0.5`.