### PR TITLE
add notebook, use convention-based .NET Interactive formatter

### DIFF
--- a/TRexLib.InteractiveExtension/Bind.cs
+++ b/TRexLib.InteractiveExtension/Bind.cs
@@ -1,0 +1,16 @@
+﻿using System.CommandLine.Binding;
+
+internal static class Bind
+{
+    public static ServiceProviderBinder<T> FromServiceProvider<T>() => ServiceProviderBinder<T>.Instance;
+
+    internal class ServiceProviderBinder<T> : BinderBase<T>
+    {
+        public static ServiceProviderBinder<T> Instance { get; } = new();
+
+        protected override T GetBoundValue(BindingContext bindingContext)
+        {
+            return (T)bindingContext.GetService(typeof(T));
+        }
+    }
+}

--- a/TRexLib.InteractiveExtension/KernelExtension.cs
+++ b/TRexLib.InteractiveExtension/KernelExtension.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.IO;
 using System.Linq;
 using System.Text.Encodings.Web;
@@ -12,173 +11,180 @@ using Microsoft.DotNet.Interactive.Utility;
 using XPlot.Plotly;
 using static Microsoft.DotNet.Interactive.Formatting.PocketViewTags;
 
-namespace TRexLib.InteractiveExtension
+namespace TRexLib.InteractiveExtension;
+
+public class KernelExtension : IKernelExtension
 {
-    public class KernelExtension : IKernelExtension
+    public Task OnLoadAsync(Kernel kernel)
     {
-        public Task OnLoadAsync(Kernel kernel)
-        {
-            RegisterFormatters();
+        RegisterFormatters();
 
-            if (kernel is { } kernelBase)
+        if (kernel is { } kernelBase)
+        {
+            var trex = new Command("#!t-rex", "Run unit tests from a notebook.")
             {
-                var trex = new Command("#!t-rex", "Run unit tests from a notebook.")
+                RunCommand(),
+                ShowCommand()
+            };
+            kernelBase.AddDirective(trex);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static Command RunCommand()
+    {
+        var projectArg = new Argument<FileSystemInfo>("project", getDefaultValue: () => new DirectoryInfo(Directory.GetCurrentDirectory()))
+        {
+            Description = "The project or solution file to operate on. If a file is not specified, the command will search the current directory for one."
+        }.ExistingOnly();
+
+        var runTestsCommand = new Command("run", "Runs unit tests using dotnet test")
+        {
+            projectArg
+        };
+
+        runTestsCommand.SetHandler(
+            RunTests, 
+            projectArg, 
+            Bind.FromServiceProvider<KernelInvocationContext>());
+
+        return runTestsCommand;
+    }
+
+    private static Command ShowCommand()
+    {
+        var dirArg = new Argument<DirectoryInfo>("dir", getDefaultValue: () => new DirectoryInfo(Directory.GetCurrentDirectory()))
+        {
+            Description = "The directory under which to search for .trx files"
+        }.ExistingOnly();
+
+        var showTestsCommand = new Command("show", "Show the results of the latest test run")
+        {
+            dirArg
+        };
+
+        showTestsCommand.SetHandler(
+            ShowTests, 
+            dirArg, 
+            Bind.FromServiceProvider<KernelInvocationContext>());
+
+        return showTestsCommand;
+    }
+
+    private static async Task RunTests(FileSystemInfo project, KernelInvocationContext context)
+    {
+        var dotnet = new Dotnet();
+
+        var process = dotnet.StartProcess(
+            $"test -l:trx \"{project.FullName}\"",
+            output => context.DisplayStandardOut(output + "\n"),
+            error => context.DisplayStandardError(error + "\n"));
+
+        await process.WaitForExitAsync();
+
+        var dir = project switch
+        {
+            DirectoryInfo directoryInfo => directoryInfo,
+            FileInfo fileInfo => fileInfo.Directory,
+            _ => throw new ArgumentOutOfRangeException(nameof(project))
+        };
+
+        ShowTests(dir, context);
+    }
+
+    private static void ShowTests(DirectoryInfo dir, KernelInvocationContext context)
+    {
+        var trxFiles = TestResultSet.FindTrxFiles(dir.FullName);
+
+        var results = TestResultSet.Create(trxFiles);
+
+        context.Display(results);
+    }
+
+    private void RegisterFormatters()
+    {
+        Formatter.Register<TestResultSet>(FormatTestResultSet, HtmlFormatter.MimeType);
+    }
+
+    private void FormatTestResultSet(TestResultSet resultSet, TextWriter writer)
+    {
+        var pieChart = new Pie
+        {
+            values = new[]
+            {
+                resultSet.Count(r => r.Outcome == TestOutcome.Passed),
+                resultSet.Count(r => r.Outcome == TestOutcome.Failed),
+                resultSet.Count(r => r.Outcome == TestOutcome.NotExecuted),
+            },
+            labels = new[]
+            {
+                "Passed",
+                "Failed",
+                "Skipped"
+            },
+            marker = new Marker
+            {
+                colors = new[]
                 {
-                    RunCommand(),
-                    ShowCommand()
-                };
-                kernelBase.AddDirective(trex);
-            }
+                    "green",
+                    "red",
+                    "#9b870c"
+                }
+            },
+            textinfo = "value",
+            hole = 0.4
+        };
 
-            return Task.CompletedTask;
-        }
+        var chart = Chart.Plot(pieChart);
 
-        private static Command RunCommand()
+        IHtmlContent view = div(
+            div(chart.GetHtmlContent()),
+            table[style: "width=100%"](
+                thead(
+                    tr(
+                        th[style: "text-align:left;width=70%"]("Test"),
+                        th[style: "width=15%"]("Result"),
+                        th[style: "width=15%"]("Duration"))),
+                tbody(
+                    resultSet.OrderBy(r => r.Outcome switch
+                             {
+                                 TestOutcome.Failed => 0,
+                                 TestOutcome.Passed => 1,
+                                 _ => 2
+                             })
+                             .ThenBy(r => r.FullyQualifiedTestName)
+                             .Select(result =>
+                             {
+                                 // allow line breaks at periods if wrapping is needed
+                                 var testName = Kernel.HTML(result.FullyQualifiedTestName.Replace(".", "&#8203."));
+
+                                 var content =
+                                     result.Outcome == TestOutcome.Failed
+                                         ? div(testName, br, pre[style: "padding-left:2em"](result.Output))
+                                         : testName;
+
+                                 return tr[style: OutcomeStyle(result.Outcome)](
+                                     td[style: "text-align:left;width=75%"](
+                                         content),
+                                     td[style: "width=15%"](
+                                         result.Outcome.ToString()),
+                                     td[style: "width=15%"](
+                                         result.Duration?.TotalSeconds + "s"));
+                             }))));
+
+        view.WriteTo(writer, HtmlEncoder.Default);
+    }
+
+    private string OutcomeStyle(TestOutcome outcome)
+    {
+        var color = outcome switch
         {
-            var projectArg = new Argument<FileSystemInfo>("project", getDefaultValue: () => new DirectoryInfo(Directory.GetCurrentDirectory()))
-            {
-                Description = "The project or solution file to operate on. If a file is not specified, the command will search the current directory for one."
-            }.ExistingOnly();
+            TestOutcome.Failed => "red",
+            TestOutcome.Passed => "green",
+            _ => "#9b870c",
+        };
 
-            var runTestsCommand = new Command("run", "Runs unit tests using dotnet test")
-            {
-                projectArg
-            };
-
-            runTestsCommand.SetHandler<FileSystemInfo, KernelInvocationContext>(RunTests, projectArg);
-
-            return runTestsCommand;
-        }
-
-        private static Command ShowCommand()
-        {
-            var dirArg = new Argument<DirectoryInfo>("dir", getDefaultValue: () => new DirectoryInfo(Directory.GetCurrentDirectory()))
-            {
-                Description = "The directory under which to search for .trx files"
-            }.ExistingOnly();
-
-            var showTestsCommand = new Command("show", "Show the results of the latest test run")
-            {
-                dirArg
-            };
-
-            showTestsCommand.SetHandler<DirectoryInfo, KernelInvocationContext>(ShowTests, dirArg);
-
-            return showTestsCommand;
-        }
-
-        private static async Task RunTests(FileSystemInfo project, KernelInvocationContext context)
-        {
-            var dotnet = new Dotnet();
-
-            var process = dotnet.StartProcess(
-                $"test -l:trx \"{project.FullName}\"",
-                output => context.DisplayStandardOut(output + "\n"),
-                error => context.DisplayStandardError(error + "\n"));
-
-            await process.WaitForExitAsync();
-
-            var dir = project switch
-            {
-                DirectoryInfo directoryInfo => directoryInfo,
-                FileInfo fileInfo => fileInfo.Directory,
-                _ => throw new ArgumentOutOfRangeException(nameof(project))
-            };
-
-            ShowTests(dir, context);
-        }
-
-        private static void ShowTests(DirectoryInfo dir, KernelInvocationContext context)
-        {
-            var trxFiles = TestResultSet.FindTrxFiles(dir.FullName);
-
-            var results = TestResultSet.Create(trxFiles);
-
-            context.Display(results);
-        }
-
-        private void RegisterFormatters()
-        {
-            Formatter.Register<TestResultSet>((set, writer) =>
-            {
-                var pieChart = new Pie
-                {
-                    values = new[]
-                    {
-                        set.Count(r => r.Outcome == TestOutcome.Passed),
-                        set.Count(r => r.Outcome == TestOutcome.Failed),
-                        set.Count(r => r.Outcome == TestOutcome.NotExecuted),
-                    },
-                    labels = new[]
-                    {
-                        "Passed",
-                        "Failed",
-                        "Skipped"
-                    },
-                    marker = new Marker
-                    {
-                        colors = new[]
-                        {
-                            "green",
-                            "red",
-                            "#9b870c"
-                        }
-                    },
-                    textinfo = "value",
-                    hole = 0.4
-                };
-
-                var chart = Chart.Plot(pieChart);
-
-                IHtmlContent view = div(
-                    div(chart.GetHtmlContent()),
-                    table[style: "width=100%"](
-                        thead(
-                            tr(
-                                th[style: "text-align:left;width=70%"]("Test"),
-                                th[style: "width=15%"]("Result"),
-                                th[style: "width=15%"]("Duration"))),
-                        tbody(
-                            set.OrderBy(r => r.Outcome switch
-                               {
-                                   TestOutcome.Failed => 0,
-                                   TestOutcome.Passed => 1,
-                                   _ => 2
-                               })
-                               .ThenBy(r => r.FullyQualifiedTestName)
-                               .Select(result =>
-                               {
-                                   // allow line breaks at periods if wrapping is needed
-                                   var testName = Kernel.HTML(result.FullyQualifiedTestName.Replace(".", "&#8203."));
-
-                                   var content = 
-                                       result.Outcome == TestOutcome.Failed
-                                           ? div(testName, br, pre[style:"padding-left:2em"](result.Output))
-                                           : testName;
-
-                                   return tr[style: OutcomeStyle(result.Outcome)](
-                                       td[style: "text-align:left;width=75%"](
-                                           content),
-                                       td[style: "width=15%"](
-                                           result.Outcome.ToString()),
-                                       td[style: "width=15%"](
-                                           result.Duration?.TotalSeconds + "s"));
-                               }))));
-
-                view.WriteTo(writer, HtmlEncoder.Default);
-            }, HtmlFormatter.MimeType);
-        }
-
-        private string OutcomeStyle(TestOutcome outcome)
-        {
-            var color = outcome switch
-            {
-                TestOutcome.Failed => "red",
-                TestOutcome.Passed => "green",
-                _ => "#9b870c",
-            };
-
-            return $"color:{color}";
-        }
+        return $"color:{color}";
     }
 }

--- a/TRexLib.InteractiveExtension/TRexLib.InteractiveExtension.csproj
+++ b/TRexLib.InteractiveExtension/TRexLib.InteractiveExtension.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="microsoft.dotnet.interactive" Version="1.0.0-beta.22207.1" />
-    <PackageReference Include="microsoft.dotnet.interactive.formatting" Version="1.0.0-beta.22207.1" />
+    <PackageReference Include="microsoft.dotnet.interactive" Version="1.0.0-beta.22362.4" />
+    <PackageReference Include="microsoft.dotnet.interactive.formatting" Version="1.0.0-beta.22362.4" />
     <PackageReference Include="xplot.plotly" Version="4.0.6" />
   </ItemGroup>
 

--- a/TRexLib.Tests/DisplayResultsDiscoveryTests.cs
+++ b/TRexLib.Tests/DisplayResultsDiscoveryTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using System.CommandLine.Parsing;
 using System.IO;
@@ -68,6 +67,19 @@ namespace TRexLib.Tests
 
             var results = JsonConvert.DeserializeObject<TestResultSet>(console.Out.ToString(), converters);
             results.Should().HaveCount(18);
+        }
+
+        [Fact]
+        public async Task When_multiple_TRX_files_exist_in_the_directory_all_are_read_when_all_flag_is_passed()
+        {
+            var directoryPath = new DirectoryInfo(Path.Combine("TRXs", "2")).FullName;
+
+            await CommandLine.Parser.InvokeAsync($"--path \"{directoryPath}\" --format json --all", console);
+
+            output.WriteLine(console.Out.ToString());
+
+            var results = JsonConvert.DeserializeObject<TestResultSet>(console.Out.ToString(), converters);
+            results.Count.Should().Be(36);
         }
 
         [Fact]

--- a/TRexLib.Tests/TRexLib.Tests.csproj
+++ b/TRexLib.Tests/TRexLib.Tests.csproj
@@ -13,20 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.IO.FileSystem" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-  
-    <PackageReference Include="FluentAssertions" Version="6.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="newtonsoft.json" Version="13.0.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
   
   <ItemGroup>
@@ -53,4 +41,13 @@
     </None>
   </ItemGroup>
   
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/TRexLib/DirectoryInfoExtensions.cs
+++ b/TRexLib/DirectoryInfoExtensions.cs
@@ -1,21 +1,19 @@
 using System.IO;
 
-namespace TRexLib
+namespace TRexLib;
+
+internal static class DirectoryInfoExtensions
 {
-    internal static class DirectoryInfoExtensions
+    private static readonly string pathSeparator = new string(Path.DirectorySeparatorChar, 1);
+
+    public static DirectoryInfo EnsureTrailingSlash(this DirectoryInfo directory)
     {
-        private static readonly string pathSeparator = new string(Path.DirectorySeparatorChar, 1);
-
-        public static DirectoryInfo EnsureTrailingSlash(this DirectoryInfo directory)
+        if (!directory.FullName
+                      .EndsWith(pathSeparator))
         {
-            if (!directory.FullName
-                          .EndsWith(pathSeparator))
-            {
-                return new DirectoryInfo(directory.FullName + Path.DirectorySeparatorChar);
-            }
-
-            return directory;
+            return new DirectoryInfo(directory.FullName + Path.DirectorySeparatorChar);
         }
+
+        return directory;
     }
 }
-

--- a/TRexLib/DotNetInteractiveFormatters.cs
+++ b/TRexLib/DotNetInteractiveFormatters.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using static System.Net.WebUtility;
+
+namespace TRexLib;
+
+[AttributeUsage(AttributeTargets.Class)]
+internal class TypeFormatterSourceAttribute : Attribute
+{
+    public TypeFormatterSourceAttribute(Type formatterSourceType)
+    {
+        FormatterSourceType = formatterSourceType;
+    }
+
+    public Type FormatterSourceType { get; }
+}
+
+internal class TypeFormatterSource
+{
+    public IEnumerable<object> CreateTypeFormatters()
+    {
+        yield return new TestResultPlainTextFormatter();
+        yield return new TestResultSetPlainTextFormatter();
+        yield return new TestResultSetHtmlFormatter();
+    }
+}
+
+internal class TestResultPlainTextFormatter
+{
+    public string MimeType => "text/plain";
+
+    public bool Format(object instance, TextWriter writer)
+    {
+        if (instance is not TestResult result)
+        {
+            return false;
+        }
+
+        writer.Write(result.ToString());
+
+        return true;
+    }
+}
+
+internal class TestResultSetPlainTextFormatter
+{
+    public string MimeType => "text/plain";
+
+    public bool Format(object instance, TextWriter writer)
+    {
+        if (instance is not TestResultSet resultSet)
+        {
+            return false;
+        }
+
+        Write(resultSet.Passed, $"✅ Passed ({resultSet.Passed.Count})");
+
+        Write(resultSet.Failed, $"❌ Failed ({resultSet.Failed.Count})");
+
+        if (resultSet.NotExecuted.Any())
+        {
+            Write(resultSet.NotExecuted, $"⚠️ Not executed {resultSet.NotExecuted.Count}");
+        }
+
+        return true;
+
+        void Write(IEnumerable<TestResult> testResultSet, string summary)
+        {
+            foreach (var result in testResultSet)
+            {
+                writer.WriteLine(result);
+            }
+        }
+    }
+}
+
+internal class TestResultSetHtmlFormatter
+{
+    public string MimeType => "text/html";
+
+    public bool Format(object instance, TextWriter writer)
+    {
+        if (instance is not TestResultSet resultSet)
+        {
+            return false;
+        }
+
+        Write(resultSet.Passed, $"✅ Passed ({resultSet.Passed.Count})");
+
+        Write(resultSet.Failed, $"❌ Failed ({resultSet.Failed.Count})");
+
+        if (resultSet.NotExecuted.Any())
+        {
+            Write(resultSet.NotExecuted, $"⚠️ Not executed {resultSet.NotExecuted.Count}");
+        }
+
+        return true;
+
+        void Write(IEnumerable<TestResult> testResultSet, string summary)
+        {
+            writer.Write("<details>");
+            writer.Write($"<summary>{HtmlEncode(summary)}</summary>");
+
+            foreach (var result in testResultSet)
+            {
+                writer.Write("<div>");
+
+                if (!string.IsNullOrEmpty(result.Output))
+                {
+                    var output = result.Output + "\n\n" + result.Stacktrace;
+                    writer.Write("<details>");
+                    writer.Write("<summary>");
+                    WriteTestName(result);
+                    writer.Write("</summary>");
+                    writer.Write($"<pre>{HtmlEncode(output)}</pre>");
+                    writer.Write("</details>");
+                }
+                else
+                {
+                    WriteTestName(result);
+                }
+
+                writer.Write("</div>");
+            }
+
+            writer.Write("</details>");
+        }
+
+        void WriteTestName(TestResult result)
+        {
+            writer.Write($"{HtmlEncode(result.ClassName)}.<b>{HtmlEncode(result.TestName)}</b>");
+        }
+    }
+}

--- a/TRexLib/TRexLib.csproj
+++ b/TRexLib/TRexLib.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>
 
-    <Title>A library for parsing trx files</Title>
+    <Title>A library for parsing .trx files</Title>
     <Description>With t-rex, you can explore the results of your most recent test run. It discovers, parses, and displays the contents of .trx files.</Description>
     <Authors>jonsequitur</Authors>
     <PackageTags>dotnet testing trx</PackageTags>
@@ -17,9 +17,5 @@
     <Compile Remove="TestResults\**" />
     <EmbeddedResource Remove="TestResults\**" />
     <None Remove="TestResults\**" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="5.0.0-alpha1.19523.8" />
   </ItemGroup>
 </Project>

--- a/TRexLib/TestResult.cs
+++ b/TRexLib/TestResult.cs
@@ -2,55 +2,71 @@
 using System.IO;
 using System.Linq;
 
-namespace TRexLib
+namespace TRexLib;
+
+[TypeFormatterSource(typeof(TypeFormatterSource))]
+public class TestResult
 {
-    public class TestResult
+    public TestResult(
+        string fullyQualifiedTestName,
+        TestOutcome outcome,
+        TimeSpan? duration = null,
+        DateTimeOffset? startTime = null,
+        DateTimeOffset? endTime = null,
+        DirectoryInfo testProjectDirectory = null,
+        FileInfo testOutputFile = null,
+        FileInfo codebase = null,
+        string output = null,
+        string stacktrace = null)
     {
-        public TestResult(
-            string fullyQualifiedTestName,
-            TestOutcome outcome,
-            TimeSpan? duration = null,
-            DateTimeOffset? startTime = null,
-            DateTimeOffset? endTime = null,
-            DirectoryInfo testProjectDirectory = null,
-            FileInfo testOutputFile = null,
-            FileInfo codebase = null,
-            string output = null,
-            string stacktrace = null)
+        FullyQualifiedTestName = fullyQualifiedTestName;
+        Duration = duration;
+        StartTime = startTime;
+        EndTime = endTime;
+        Outcome = outcome;
+        TestProjectDirectory = testProjectDirectory;
+        TestOutputFile = testOutputFile;
+        Codebase = codebase;
+        Output = output;
+        Stacktrace = stacktrace;
+
+        var testNameParts = fullyQualifiedTestName.Split('.');
+        TestName = testNameParts[^1];
+        if (testNameParts.Length > 1)
         {
-            FullyQualifiedTestName = fullyQualifiedTestName;
-            Duration = duration;
-            StartTime = startTime;
-            EndTime = endTime;
-            Outcome = outcome;
-            TestProjectDirectory = testProjectDirectory;
-            TestOutputFile = testOutputFile;
-            Codebase = codebase;
-            Output = output;
-            Stacktrace = stacktrace;
-
-            var testNameParts = fullyQualifiedTestName.Split('.');
-            TestName = testNameParts[testNameParts.Length - 1];
-            if (testNameParts.Length > 1)
-            {
-                ClassName = testNameParts[testNameParts.Length - 2];
-                Namespace = string.Join(".", testNameParts.Take(testNameParts.Length - 2));
-            }
+            ClassName = testNameParts[^2];
+            Namespace = string.Join(".", testNameParts.Take(testNameParts.Length - 2));
         }
+    }
 
-        public string FullyQualifiedTestName { get; }
-        public TimeSpan? Duration { get; }
-        public DateTimeOffset? StartTime { get; }
-        public DateTimeOffset? EndTime { get; }
-        public TestOutcome Outcome { get; }
-        public DirectoryInfo TestProjectDirectory { get; }
-        public FileInfo TestOutputFile { get; }
-        public FileInfo Codebase { get; }
-        public string Output { get; }
-        public string Stacktrace { get; }
+    public string FullyQualifiedTestName { get; }
+    public TimeSpan? Duration { get; }
+    public DateTimeOffset? StartTime { get; }
+    public DateTimeOffset? EndTime { get; }
+    public TestOutcome Outcome { get; }
+    public DirectoryInfo TestProjectDirectory { get; }
+    public FileInfo TestOutputFile { get; }
+    public FileInfo Codebase { get; }
+    public string Output { get; }
+    public string Stacktrace { get; }
 
-        public string Namespace { get; }
-        public string TestName { get; }
-        public string ClassName { get; }
+    public string Namespace { get; }
+    public string TestName { get; }
+    public string ClassName { get; }
+
+    public override string ToString()
+    {
+        var badge = Outcome switch
+        {
+            TestOutcome.Failed => "❌",
+            TestOutcome.Passed => "✅",
+            TestOutcome.NotExecuted => "⚠️",
+            TestOutcome.Inconclusive => "⚠️",
+            TestOutcome.Timeout => "⌚",
+            TestOutcome.Pending => "⏳",
+            _ => throw new ArgumentOutOfRangeException()
+        };
+
+        return $"{badge} {FullyQualifiedTestName}";
     }
 }

--- a/TRexLib/TestResultSet.cs
+++ b/TRexLib/TestResultSet.cs
@@ -4,76 +4,92 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-namespace TRexLib
+namespace TRexLib;
+
+[TypeFormatterSource(typeof(TypeFormatterSource))]
+public class TestResultSet : IReadOnlyList<TestResult>
 {
-    public class TestResultSet : IEnumerable<TestResult>
+    private readonly Lazy<(List<TestResult> all, List<TestResult> passed, List<TestResult> failed, List<TestResult> notExecuted)> evaluated;
+
+    public TestResultSet(IEnumerable<TestResult> testResults)
     {
-        private readonly Lazy<(List<TestResult> all, List<TestResult> passed, List<TestResult> failed, List<TestResult> notExecuted)> evaluated;
-
-        public TestResultSet(IEnumerable<TestResult> testResults)
+        evaluated = new Lazy<(List<TestResult>, List<TestResult>, List<TestResult>, List<TestResult>)>(() =>
         {
-            evaluated = new Lazy<(List<TestResult>, List<TestResult>, List<TestResult>, List<TestResult>)>(() =>
-            {
-                var all = new List<TestResult>();
-                var passed = new List<TestResult>();
-                var failed = new List<TestResult>();
-                var notExecuted = new List<TestResult>();
+            var all = new List<TestResult>();
+            var passed = new List<TestResult>();
+            var failed = new List<TestResult>();
+            var notExecuted = new List<TestResult>();
 
-                foreach (var testResult in testResults.OrderBy(r => r.FullyQualifiedTestName))
+            foreach (var testResult in testResults.OrderBy(r => r.FullyQualifiedTestName))
+            {
+                all.Add(testResult);
+
+                switch (testResult.Outcome)
                 {
-                    all.Add(testResult);
-
-                    switch (testResult.Outcome)
-                    {
-                        case TestOutcome.Passed:
-                            passed.Add(testResult);
-                            break;
-                        case TestOutcome.Failed:
-                            failed.Add(testResult);
-                            break;
-                        case TestOutcome.NotExecuted:
-                            notExecuted.Add(testResult);
-                            break;
-                    }
+                    case TestOutcome.Passed:
+                        passed.Add(testResult);
+                        break;
+                    case TestOutcome.Failed:
+                        failed.Add(testResult);
+                        break;
+                    case TestOutcome.NotExecuted:
+                        notExecuted.Add(testResult);
+                        break;
                 }
-
-                return (all, passed, failed, notExecuted);
-            });
-        }
-
-        public IReadOnlyCollection<TestResult> Passed => evaluated.Value.passed;
-
-        public IReadOnlyCollection<TestResult> Failed => evaluated.Value.failed;
-
-        public IReadOnlyCollection<TestResult> NotExecuted => evaluated.Value.notExecuted;
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-        public IEnumerator<TestResult> GetEnumerator() => evaluated.Value.all.GetEnumerator();
-        
-        public static TestResultSet Create(
-            IEnumerable<FileInfo> files)
-        {
-            var testResults = new List<TestResult>();
-
-            foreach (var file in files)
-            {
-                testResults.AddRange(file.Parse());
             }
 
-            return new TestResultSet(testResults);
+            return (all, passed, failed, notExecuted);
+        });
+    }
+
+    public IReadOnlyCollection<TestResult> Passed => evaluated.Value.passed;
+
+    public IReadOnlyCollection<TestResult> Failed => evaluated.Value.failed;
+
+    public IReadOnlyCollection<TestResult> NotExecuted => evaluated.Value.notExecuted;
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public IEnumerator<TestResult> GetEnumerator() => evaluated.Value.all.GetEnumerator();
+
+    public static TestResultSet Create(
+        IEnumerable<FileInfo> files)
+    {
+        var testResults = new List<TestResult>();
+
+        foreach (var file in files)
+        {
+            testResults.AddRange(file.Parse());
         }
 
-        public static IEnumerable<FileInfo> FindTrxFiles(string path)
-        {
-            var allFiles = new DirectoryInfo(path)
-                           .GetFiles("*.trx", SearchOption.AllDirectories)
-                           .GroupBy(f => f.Directory.FullName);
+        return new TestResultSet(testResults);
+    }
 
-            foreach (var folder in allFiles)
+    public static TestResultSet Create(string path, bool latestOnly = true) => Create(FindTrxFiles(path, latestOnly));
+
+    public static IEnumerable<FileInfo> FindTrxFiles(string path, bool latestOnly = true)
+    {
+        var allFiles = new DirectoryInfo(path)
+                       .GetFiles("*.trx", SearchOption.AllDirectories)
+                       .GroupBy(f => f.Directory.FullName);
+
+        foreach (var folder in allFiles)
+        {
+            if (latestOnly)
             {
                 yield return folder.OrderBy(f => f.LastWriteTime).Last();
             }
+            else
+            {
+                foreach (var fileInfo in folder)
+                {
+                    yield return fileInfo;
+                }
+            }
         }
     }
+
+    public int Count => evaluated.Value.all.Count;
+
+    public TestResult this[int index] => evaluated.Value.all[index];
 }

--- a/t-rex playground.ipynb
+++ b/t-rex playground.ipynb
@@ -1,0 +1,376 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## First, let's run some tests.\n",
+    "\n",
+    "Running `dotnet test`  with the `-l trx` option tells the logger to produce `.trx` files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "pwsh"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.pwsh"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "dotnet test -l trx"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Take a look at the results\n",
+    "\n",
+    "Once we have `.trx` files, we can use TRexLib to find, parse, and display the results. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "using System.IO;\n",
+    "using Microsoft.DotNet.Interactive;\n",
+    "using Microsoft.DotNet.Interactive.Commands;\n",
+    "\n",
+    "var dll = Directory.GetFiles(\"./TRexLib/bin\", @\"TRexLib.dll\", SearchOption.AllDirectories )\n",
+    "                   .Where(f => f.Contains(\"Debug\"))\n",
+    "                   .Where(f => f.Contains(\"net6.0\"))\n",
+    "                   .SingleOrDefault();\n",
+    "\n",
+    "var submitCode = new SubmitCode(@$\"#r \"\"{dll}\"\"\", \"csharp\");\n",
+    "\n",
+    "Kernel.Root.FindKernel(\"csharp\").DeferCommand(submitCode);\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "Formatter.Register<IReadOnlyCollection<TestResult>>(r => , \"text/html\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "using TRexLib;\n",
+    "var results = TestResultSet.Create(\".\", latestOnly: true);\n",
+    "results.First()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "Formatter.RecursionLimit = 5;\n",
+    "Enumerable.Range(1, 10).Select(i => new FileInfo($\"{i}.txt\")).Display(\"text/plain\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "using Microsoft.DotNet.Interactive.Formatting;\n",
+    "\n",
+    "results.ToDisplayString(\"application/json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "using Microsoft.DotNet.Interactive.Formatting;\n",
+    "\n",
+    "var resultsCsv = results.ToDisplayString(\"text/csv\");\n",
+    "\n",
+    "resultsCsv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#  Let's plot!\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## F#"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "fsharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.fsharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#r \"nuget: Plotly.NET.Interactive\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "fsharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.fsharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "open Plotly.NET \n",
+    "\n",
+    "let values = [5.;0.;3.;2.;3.]\n",
+    "let multiText = [\"At\";\"Bt\";\"Ct\";\"Dt\";\"Et\"]\n",
+    "\n",
+    "let sunburstChart =\n",
+    "    Chart.Sunburst(\n",
+    "        [\"A\";\"B\";\"C\";\"D\";\"E\"],\n",
+    "        [\"\";\"\";\"B\";\"B\";\"\"],\n",
+    "        Values=values,\n",
+    "        MultiText=multiText\n",
+    "    )\n",
+    "\n",
+    "sunburstChart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "fsharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.fsharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#r \"nuget:microsoft.data.analysis\"\n",
+    "#!share  --from csharp resultsCsv\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "fsharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.fsharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "open Microsoft.Data.Analysis\n",
+    "\n",
+    "let df = DataFrame.LoadCsvFromString(resultsCsv)\n",
+    "\n",
+    "df\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "javascript"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.javascript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "    require.config({ \n",
+    "    paths: { \"plotly\": \"https://cdn.plot.ly/plotly-2.12.1.min\"  } \n",
+    "});\n",
+    "\n",
+    "require([\"plotly\"], plotly => {\n",
+    "    console.log(plotly);\n",
+    "});"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "javascript"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.javascript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "(require.config({'paths': {'plotly': 'https://cdn.plot.ly/plotly-2.12.1.min'}}) || require)(['plotly'], plotly => {\n",
+    "    plotly.plot( document.getElementById('tester'), [{\n",
+    "        x: [1, 2, 3, 4, 5],\n",
+    "        y: [1, 2, 4, 8, 16] }], { \n",
+    "        margin: { t: 0 } }, {showSendToCloud:true} );\n",
+    "}); "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "html"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.html"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "<script src=\"https://cdn.plot.ly/plotly-2.12.1.min.js\"></script>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "javascript"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.javascript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "var data = [{x:[0,1,2], y:[3,2,1], type: 'bar'}];\n",
+    "var layout = {fileopt : \"overwrite\", filename : \"simple-node-example\"};\n",
+    "\n",
+    "plotly.plot(data, layout, function (err, msg) {\n",
+    "    if (err) return console.log(err);\n",
+    "    console.log(msg);\n",
+    "});"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "javascript"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.javascript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "var plotly = require('plotly')(\"DemoAccount\", \"lr1c37zw81\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "javascript"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.javascript"
+    }
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "name": "C#"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/t-rex/t-rex.csproj
+++ b/t-rex/t-rex.csproj
@@ -22,6 +22,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\TRexLib.InteractiveExtension\Bind.cs" Link="Bind.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\TRexLib\TRexLib.csproj" />
   </ItemGroup>
 
@@ -31,7 +35,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22166.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
This PR also add an `--all` option for when you want to aggregate all `.trx` files under `--path` rather than only choose the latest in a given directory.