### PR TITLE
rename `*File*` to `*Document*`

### DIFF
--- a/TRexLib.Tests/TestOutputDocumentParserTests.cs
+++ b/TRexLib.Tests/TestOutputDocumentParserTests.cs
@@ -8,11 +8,11 @@ using Xunit.Abstractions;
 
 namespace TRexLib.Tests;
 
-public class TestOutputFileParserTests
+public class TestOutputDocumentParserTests
 {
     private readonly ITestOutputHelper output;
 
-    public TestOutputFileParserTests(ITestOutputHelper output)
+    public TestOutputDocumentParserTests(ITestOutputHelper output)
     {
         this.output = output;
     }

--- a/TRexLib.Tests/TestOutputDocumentWriterTests.cs
+++ b/TRexLib.Tests/TestOutputDocumentWriterTests.cs
@@ -6,11 +6,11 @@ using Xunit.Abstractions;
 
 namespace TRexLib.Tests;
 
-public class TestOutputFileWriterTests
+public class TestOutputDocumentWriterTests
 {
     private readonly ITestOutputHelper _output;
 
-    public TestOutputFileWriterTests(ITestOutputHelper output)
+    public TestOutputDocumentWriterTests(ITestOutputHelper output)
     {
         _output = output;
     }
@@ -88,11 +88,11 @@ public class TestOutputFileWriterTests
     {
         using var writer = new StringWriter();
 
-        new TestOutputFileWriter(writer).Write(original);
+        new TestOutputDocumentWriter(writer).Write(original);
 
         _output.WriteLine(writer.ToString());
 
-        var roundTripped = TestOutputFileParser.Parse(writer.ToString());
+        var roundTripped = TestOutputDocumentParser.Parse(writer.ToString());
 
         return roundTripped;
     }

--- a/TRexLib/TestOutputDocumentParser.cs
+++ b/TRexLib/TestOutputDocumentParser.cs
@@ -7,7 +7,7 @@ using static System.Environment;
 
 namespace TRexLib;
 
-public static class TestOutputFileParser
+public static class TestOutputDocumentParser
 {
     public static TestResultSet Parse(this FileInfo fileInfo)
     {

--- a/TRexLib/TestOutputDocumentWriter.cs
+++ b/TRexLib/TestOutputDocumentWriter.cs
@@ -6,11 +6,11 @@ using System.Xml.Linq;
 
 namespace TRexLib;
 
-public class TestOutputFileWriter
+public class TestOutputDocumentWriter
 {
     private readonly TextWriter _writer;
 
-    public TestOutputFileWriter(TextWriter writer)
+    public TestOutputDocumentWriter(TextWriter writer)
     {
         _writer = writer;
     }


### PR DESCRIPTION
Since no file reading  or writing is required, this  naming is more accurate.